### PR TITLE
Fix dinit-serv ebuild license

### DIFF
--- a/dinit-serv/acpid-dinit/acpid-dinit-0.ebuild
+++ b/dinit-serv/acpid-dinit/acpid-dinit-0.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for acpid"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/acpid-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/base/base-0.99.10-r1.ebuild
+++ b/dinit-serv/base/base-0.99.10-r1.ebuild
@@ -15,7 +15,7 @@ else
 	S="${WORKDIR}/dinit-chimera-${PV}"
 fi
 
-LICENSE="BSD-2 Clause"
+LICENSE="BSD-2"
 SLOT=0
 
 RDEPEND=""

--- a/dinit-serv/bluez-dinit/bluez-dinit-0.ebuild
+++ b/dinit-serv/bluez-dinit/bluez-dinit-0.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for bluez bluetooth daemon"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/bluez-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/chrony-dinit/chrony-dinit-1.ebuild
+++ b/dinit-serv/chrony-dinit/chrony-dinit-1.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for chrony"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/chrony-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/dbus-dinit/dbus-dinit-2.ebuild
+++ b/dinit-serv/dbus-dinit/dbus-dinit-2.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for dbus daemon and user session"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/dbus-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/dhcpcd-dinit/dhcpcd-dinit-0.ebuild
+++ b/dinit-serv/dhcpcd-dinit/dhcpcd-dinit-0.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for dhcpcd"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/dhcpcd-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/elogind-dinit/elogind-dinit-0.ebuild
+++ b/dinit-serv/elogind-dinit/elogind-dinit-0.ebuild
@@ -4,15 +4,15 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for elogind"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/elogind-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 
+# Also needs polkit if elogind has polkit USE enabled
+# not sure how to go about that for now
 RDEPEND="
   sys-auth/elogind
   dinit-serv/dbus-dinit
-  # Also needs polkit if elogind has polkit USE enabled
-  # not sure how to go about that for now
 "
 
 src_unpack() {

--- a/dinit-serv/getty-dinit/getty-dinit-0.ebuild
+++ b/dinit-serv/getty-dinit/getty-dinit-0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 DESCRIPTION="Dinit service description files for tty"
 # Unsure where I got this set of service descriptions but it was on my system
 # HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/nyagetty"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/iwd-dinit/iwd-dinit-0.ebuild
+++ b/dinit-serv/iwd-dinit/iwd-dinit-0.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for iwd"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/iwd-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/networkmanager-dinit/networkmanager-dinit-1.ebuild
+++ b/dinit-serv/networkmanager-dinit/networkmanager-dinit-1.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for networkmanager"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/networkmanager-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/openssh-dinit/openssh-dinit-0.ebuild
+++ b/dinit-serv/openssh-dinit/openssh-dinit-0.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for openssh ssh daemon"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/openssh-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/polkit-dinit/polkit-dinit-1.ebuild
+++ b/dinit-serv/polkit-dinit/polkit-dinit-1.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for polkit"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/polkit-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/rtkit-dinit/rtkit-dinit-0.ebuild
+++ b/dinit-serv/rtkit-dinit/rtkit-dinit-0.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for rtkit"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/rtkit-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/seatd-dinit/seatd-dinit-0.ebuild
+++ b/dinit-serv/seatd-dinit/seatd-dinit-0.ebuild
@@ -4,7 +4,7 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for seatd"
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/seatd-dinit"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/dinit-serv/serv-skel.ebuild
+++ b/dinit-serv/serv-skel.ebuild
@@ -4,12 +4,12 @@ EAPI=8
 
 DESCRIPTION="Dinit service description files for "
 HOMEPAGE="https://pkgs.chimera-linux.org/package/current/main/x86_64/"
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64"
 
 RDEPEND="
-  
+
 "
 
 src_unpack() {

--- a/sys-auth/turnstile/turnstile-0.1.10.ebuild
+++ b/sys-auth/turnstile/turnstile-0.1.10.ebuild
@@ -15,7 +15,7 @@ else
   SRC_URI="https://github.com/chimera-linux/${PN}/archive/refs/tags/v${PV}.tar.gz"
 fi
 
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 
 #RDEPEND=""
@@ -29,7 +29,7 @@ src_prepare() {
   eapply "${FILESDIR}/fix-backend-exec-failure.patch"
   # This patch is currently hardcoded, but on a multilib 64 bit system, dinit-chimera will
   # install to /usr/lib64. Until I make some final decisions on where system services
-  # should go *in gentoo*, I'm going to make this package work as well as possible under 
+  # should go *in gentoo*, I'm going to make this package work as well as possible under
   # my system configuration.
   eapply "${FILESDIR}/multilib.patch"
   eapply_user
@@ -46,7 +46,7 @@ src_configure() {
 
 src_install() {
   meson_src_install
-  
+
   insinto /etc/pam.d
   doins "${FILESDIR}/system-login"
 }

--- a/sys-auth/turnstile/turnstile-9999.ebuild
+++ b/sys-auth/turnstile/turnstile-9999.ebuild
@@ -15,7 +15,7 @@ else
   SRC_URI="https://github.com/chimera-linux/${PN}/archive/refs/tags/v${PV}.tar.gz"
 fi
 
-LICENSE="BSD-2-Clause"
+LICENSE="BSD-2"
 SLOT="0"
 
 #RDEPEND=""
@@ -29,7 +29,7 @@ src_prepare() {
   eapply "${FILESDIR}/fix-backend-exec-failure.patch"
   # This patch is currently hardcoded, but on a multilib 64 bit system, dinit-chimera will
   # install to /usr/lib64. Until I make some final decisions on where system services
-  # should go *in gentoo*, I'm going to make this package work as well as possible under 
+  # should go *in gentoo*, I'm going to make this package work as well as possible under
   # my system configuration.
   eapply "${FILESDIR}/multilib.patch"
   eapply_user
@@ -46,7 +46,7 @@ src_configure() {
 
 src_install() {
   meson_src_install
-  
+
   insinto /etc/pam.d
   doins "${FILESDIR}/system-login"
 }


### PR DESCRIPTION
I think we should use `LICENSE="BSD-2"` instead of `LICENSE="BSD-2-Clause"` because it's how portage mark packages license as BSD 2-Clause